### PR TITLE
Feature/#8

### DIFF
--- a/src/pkg/clerk/expand/services/index.ts
+++ b/src/pkg/clerk/expand/services/index.ts
@@ -14,7 +14,10 @@ function Yaml(yamlData: any) {
                     for (const [i,loc] of Object.entries(locations)) {
                         if(parseInt(i) == locations.length - 1){
                             // `hoge.foo.bar`の`bar`にあたる場合元々の`hoge.foo.bar`に入っていた値を複製
-                            currentYaml[loc] = yamlData[currentLocation]
+                            // その際その値がobjectならそれを代入それ以外ならnullを代入
+                            currentYaml[loc] = (Object.prototype.toString.call(yamlData[currentLocation]) == '[object Object]')
+                                             ? yamlData[currentLocation]
+                                             : null
                         } else {
                             // `hoge.foo.bar`を再帰的にObjectに変換していく
                             currentYaml[loc] = {}

--- a/src/pkg/clerk/generate/services/index.ts
+++ b/src/pkg/clerk/generate/services/index.ts
@@ -5,13 +5,22 @@ const shell = require('shelljs')
 function Package(schema: any, footprint: string, lang: string, template: string){
     try {
         for (let currentLocation of Object.keys(schema)) {
+            // 意図せぬ再帰処理を防ぐ
+            if(currentLocation == '0') return
 
-            let path = `${footprint}/${currentLocation}/${schema[currentLocation]}`
+            // ツリー構造の終端であるかを判断
+            const isEnd = schema[currentLocation] == null
+            || /\,/.test(schema[currentLocation])
+            || typeof(schema[currentLocation]) == 'string'
+
+            let path = (isEnd)
+                     ? `${footprint}/${currentLocation}/null`
+                     : `${footprint}/${currentLocation}/${schema[currentLocation]}`
             path = path.replace("null", "").replace("[object Object]", "")
-        
+
             if(!shell.test("-e", path)){
                 shell.mkdir(path)
-                if(schema[currentLocation] == null){
+                if(isEnd){
                     shell.cp("-R", `${process.env.HOME}/.pkgen/template/${template}/${lang}/*`, path)
                     console.log(`${chalk.green.bold("[generate]")} to ${chalk.yellow(path)}`)
                 }


### PR DESCRIPTION
#8 の解決. 
- yamlのツリー構造がobject以外だった場合無限ループが発生するバグを修正
- パッケージに含まれる関数などをyamlの配列形式で記載する事ができるようになった
